### PR TITLE
Fix URL in README cloning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Rust implementation of the Truthcoin protocol, providing a decentralized oracl
 ### Installation
 
 ```bash
-git clone https://github.com/yourusername/truthcoin-rs.git
+git clone git@github.com:LayerTwo-Labs/truthcoin-rs.git
 cd truthcoin-rs
 cargo build --release
 ```


### PR DESCRIPTION
Changes instructions to utilize a complete SSH link rather than HTTPS which is standard practice for cloning repos
